### PR TITLE
Add support for Django 1.5's streaming response

### DIFF
--- a/django_webtest/response.py
+++ b/django_webtest/response.py
@@ -9,6 +9,7 @@ from webtest import TestResponse
 from django.test import Client
 from django.http import SimpleCookie
 
+
 class DjangoWebtestResponse(TestResponse):
     """
     WebOb's Response quacking more like django's HttpResponse.
@@ -16,6 +17,8 @@ class DjangoWebtestResponse(TestResponse):
     This is here to make more django's TestCase asserts work,
     not to provide a generally useful proxy.
     """
+    streaming = False
+
     @property
     def status_code(self):
         return self.status_int

--- a/tox.ini
+++ b/tox.ini
@@ -26,7 +26,7 @@ deps=
 
 [django15]
 deps=
-    git+https://github.com/django/django.git@fbd4b3a5188d0b488648f1fdd2339e1eac6722a2#egg=django
+    git+https://github.com/django/django.git@64f1a175bd8228493ef600a62cd2f331a17787e6#egg=django
 
 [testenv:dj15]
 deps=


### PR DESCRIPTION
Well, by "add support" I mean provide a 'streaming' attribute to the
response class that allows Django's testrunner to not choke when
processing the response.  Without this, you get an AttributeError from here:
https://github.com/django/django/blob/stable/1.5.x/django/test/testcases.py#L639

I think the right fix is in django-webtest rather than in Django itself.

The commit ID in tox.ini for Django 1.5 was 4 months out of date.  When
I bumped it to today's latest commit, the tests started failing (hence I
didn't need to write a new failing test).
