### PR TITLE
to_string import fixed

### DIFF
--- a/django_webtest/__init__.py
+++ b/django_webtest/__init__.py
@@ -15,7 +15,7 @@ except ImportError:
     from django.contrib.staticfiles.handlers import StaticFilesHandler
 
 from webtest import TestApp
-from webtest.compat import to_string
+from webtest.lint import to_string
 
 from django_webtest.response import DjangoWebtestResponse
 


### PR DESCRIPTION
Error:
## In [1]: from django_webtest import WebTest

ImportError                               Traceback (most recent call last)
<ipython-input-1-298cdc14eab2> in <module>()
----> 1 from django_webtest import WebTest

/home/vagrant/.virtualenvs/gsa/lib/python2.6/site-packages/django_webtest/**init**.py in <module>()
     16 
     17 from webtest import TestApp
---> 18 from webtest.compat import to_string
     19 
     20 from django_webtest.response import DjangoWebtestResponse

ImportError: cannot import name to_string

I have changed the import to:

from webtest.lint import to_string

seems to fix the issue
