### PR TITLE
Adding a formset to a form a la django dynamic formsets

### DIFF
--- a/django_webtest/forms.py
+++ b/django_webtest/forms.py
@@ -1,0 +1,14 @@
+from webtest.form import Form, Field as WebTestField
+
+def add_extra_form_to_formset_with_data(form, prefix, field_names_and_values):
+    total_forms_field_name = prefix + '-TOTAL_FORMS'
+    next_form_index = int(form[total_forms_field_name].value)
+    for extra_field_name, extra_field_value in field_names_and_values.iteritems():
+        input_field_name = '-'.join((prefix, str(next_form_index), extra_field_name))
+        extra_field = WebTestField(form, tag='input', name=input_field_name, pos=0, value=extra_field_value)
+        form.fields[input_field_name] = [extra_field]
+        form[input_field_name] = extra_field_value
+        form.field_order.append((input_field_name, extra_field))
+        form[total_forms_field_name].value = str(next_form_index + 1)
+
+Form.add_extra_form_to_formset_with_data = add_extra_form_to_formset_with_data


### PR DESCRIPTION
Not sure where to send this for a pull request. webtest seems django-agnostic, so here seemed best.

We (I work with Julien Aubert) had a test where there was javascript in the page to add a formset form with some data. In the browser this was done with javascript, using the django dynamic formset mechanism. This wasn't reproducible in webtest due to it not handling the javascript, so this code does the same as the javascript to enable the test.

No problem if you want to decline the request, just offering it in in case it might be useful for those in the same situation.
