### PR TITLE
Test against Django 1.4.6 & 1.5.2 (updated from 1.4.5 & 1.5.1)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ matrix:
 
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install:
-  - pip install "django $DJANGO_INSTALL"
+  - pip install "django $DJANGO"
   - if [[ $OLD_WEBTEST ]]; then pip install 'WebTest < 2.0'; else pip install WebTest; fi
   - python setup.py install
 


### PR DESCRIPTION
Opening this for discussion due to the recent [security releases](https://www.djangoproject.com/weblog/2013/aug/13/security-releases-issued/). The 1.3.x branch received no updates.

Apologies for the crap branch name; it's the automatic one applied when you edit via github.

Tox tests passed locally on all interpreters.
