### PR TITLE
Disable 'RemoteUserMiddleware' when patching auth

### DIFF
--- a/django_webtest/__init__.py
+++ b/django_webtest/__init__.py
@@ -209,6 +209,7 @@ class WebTestMixin(object):
     def _setup_auth_middleware(self):
         webtest_auth_middleware = 'django_webtest.middleware.WebtestUserMiddleware'
         django_auth_middleware = 'django.contrib.auth.middleware.AuthenticationMiddleware'
+        django_remote_middleware = 'django.contrib.auth.middleware.RemoteUserMiddleware'
 
         if django_auth_middleware not in settings.MIDDLEWARE_CLASSES:
             # There can be a custom AuthenticationMiddleware subclass or replacement,
@@ -219,6 +220,9 @@ class WebTestMixin(object):
         else:
             index = settings.MIDDLEWARE_CLASSES.index(django_auth_middleware)
             settings.MIDDLEWARE_CLASSES.insert(index+1, webtest_auth_middleware)
+            
+        if django_remote_middleware in settings.MIDDLEWARE_CLASSES:
+            settings.MIDDLEWARE_CLASSES.remove(django_remote_middleware)
 
     def _setup_auth_backend(self):
         backend_name = 'django_webtest.backends.WebtestUserBackend'


### PR DESCRIPTION
Remove `'django.contrib.auth.middleware.RemoteUserMiddleware'`, because having it active will automatically log out the webtest user. The reason for this behaviour is that `WebtestUserBackend` extends `RemoteUserBackend`, and the middleware detects it and automatically logs out the user.

See: https://github.com/django/django/blob/master/django/contrib/auth/middleware.py#L125
