### PR TITLE
Fix error when accessing a response's url if 'Location' is not in the response headers

### DIFF
--- a/django_webtest/response.py
+++ b/django_webtest/response.py
@@ -42,6 +42,8 @@ class DjangoWebtestResponse(TestResponse):
         if item == 'location':
             # django's test response returns location as http://testserver/,
             # WebTest returns it as http://localhost:80/
+            if not self.location:
+                return ''
             e_scheme, e_netloc, e_path, e_query, e_fragment = urlparse.urlsplit(self.location)
             if e_netloc == 'localhost:80':
                 e_netloc = 'testserver'


### PR DESCRIPTION
Accessing the 'url' attribute on a DjangoWebtestResponse instance when 'Location' is not in the response headers will currently throw the error 'NoneType' object has no attribute 'find', because the DjangoWebtestResponse class passes self.location to urlparse.urlsplit(), and that function doesn't handle None as an input. This minor change fixes it.