### PR TITLE
Fixed running of tests on Python 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 
 language: python
+python: 3.5  # this is needed to get travis to have python3.5 as well
 
 sudo: false
 
@@ -51,15 +52,6 @@ env:
   - TOXENV=py34-django19-std
   - TOXENV=py34-django19-clocale
   - TOXENV=py34-django19-postgres
-  - TOXENV=py35-django15-std
-  - TOXENV=py35-django15-clocale
-  - TOXENV=py35-django15-postgres
-  - TOXENV=py35-django16-std
-  - TOXENV=py35-django16-clocale
-  - TOXENV=py35-django16-postgres
-  - TOXENV=py35-django17-std
-  - TOXENV=py35-django17-clocale
-  - TOXENV=py35-django17-postgres
   - TOXENV=py35-django18-std
   - TOXENV=py35-django18-clocale
   - TOXENV=py35-django18-postgres

--- a/django_webtest_tests/tox2travis.py
+++ b/django_webtest_tests/tox2travis.py
@@ -2,6 +2,7 @@
 
 TRAVIS_CONF = '''
 language: python
+python: 3.5  # this is needed to get travis to have python3.5 as well
 
 sudo: false
 

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,8 @@ skip_missing_interpreters = true
 envlist =
     pypy-django19-std,
     py26-django{12,13,14,15,16}-std,
-    {py27,py34,py35}-django{15,16,17,18,19}-{std,clocale,postgres}
+    {py27,py34}-django{15,16,17,18,19}-{std,clocale,postgres},
+    py35-django{18,19}-{std,clocale,postgres}
 
 [testenv]
 deps=


### PR DESCRIPTION
Only Django 1.8+ supports Python 3.5 (see https://docs.djangoproject.com/en/dev/releases/1.7/
and https://docs.djangoproject.com/en/dev/releases/1.8/)

Previously, Travis tests were passing on Python 3.5 because the
tests were not actually running - tox skipped them because
Python 3.5 was not installed.

https://travis-ci.org/django-webtest/django-webtest/jobs/124183467
https://travis-ci.org/django-webtest/django-webtest/jobs/124183470
https://travis-ci.org/django-webtest/django-webtest/jobs/124183473
https://travis-ci.org/django-webtest/django-webtest/jobs/124183476
https://travis-ci.org/django-webtest/django-webtest/jobs/124183479

Both issues are fixed in this commit.