### PR TITLE
Fixes #69: Use 'localhost' as the HTTP_HOST to match with webtest

### DIFF
--- a/django_webtest/__init__.py
+++ b/django_webtest/__init__.py
@@ -51,7 +51,7 @@ class DjangoTestApp(TestApp):
         if user is not None:
             self.extra_environ = self._update_environ(self.extra_environ, user)
 
-    def _update_environ(self, environ, user):
+    def _update_environ(self, environ, user=None):
         environ = environ or {}
         environ.setdefault('HTTP_HOST', 'testserver')
         if user:
@@ -202,6 +202,9 @@ class DjangoTestApp(TestApp):
                 return engine.SessionStore(cookie)
         return {}
 
+    def set_cookie(self, *args, **kwargs):
+        self.extra_environ = self._update_environ(self.extra_environ)
+        return super(DjangoTestApp, self).set_cookie(*args, **kwargs)
 
 class WebTestMixin(object):
 

--- a/django_webtest_tests/testapp_tests/tests.py
+++ b/django_webtest_tests/testapp_tests/tests.py
@@ -409,3 +409,9 @@ class TestHeaderAccess(WebTest):
             response = self.app.get('/')
             response['X-Unknown-Header']
         self.assertRaises(KeyError, access_bad_header)
+
+class TestCookies(WebTest):
+    def test_cookies(self):
+        self.app.set_cookie(str('test_cookie'), str('cookie monster!'))
+        rsp = self.app.get(reverse('cookie_test'))
+        self.assertContains(rsp, 'cookie monster!')

--- a/django_webtest_tests/testapp_tests/views.py
+++ b/django_webtest_tests/testapp_tests/views.py
@@ -41,3 +41,7 @@ def protected(request):
 
 def remove_prefix_redirect(request, arg):
     return HttpResponseRedirect("/" + arg)
+
+def cookie_test(request):
+    cookie = request.COOKIES.get(str('test_cookie'), None)
+    return HttpResponse('cookie: {0}'.format(cookie))

--- a/django_webtest_tests/urls.py
+++ b/django_webtest_tests/urls.py
@@ -10,7 +10,7 @@ from django.shortcuts import render
 from django.contrib.auth.views import login
 
 from testapp_tests.views import check_password, search, set_session, \
-    protected, redirect_to_protected, remove_prefix_redirect
+    protected, redirect_to_protected, remove_prefix_redirect, cookie_test \
 
 # Uncomment the next two lines to enable the admin:
 # from django.contrib import admin
@@ -36,4 +36,5 @@ urlpatterns = (
     url(r'^protected/$', protected, name='protected'),
     url(r'^redirect-to-protected/$', redirect_to_protected, name='redirect-to-protected'),
     url(r'^remove-prefix-redirect/(.*)/$', remove_prefix_redirect, name='remove-prefix-redirect'),
+    url(r'^cookie-test/$', cookie_test, name='cookie_test'),
 )


### PR DESCRIPTION
This commit fixes issue #69.

Having HTTP_HOST not match webtest breaks cookies and doesn't appear to add any value. Thus we just make them the same.