### PR TITLE
the relative imports make pytest unhappy

### DIFF
--- a/django_webtest/backends.py
+++ b/django_webtest/backends.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 from django.utils.version import get_complete_version
 from django.contrib.auth.backends import RemoteUserBackend
-from .compat import from_wsgi_safe_string
+from django_webtest.compat import from_wsgi_safe_string
 
 class WebtestUserBackend(RemoteUserBackend):
     """ Auth backend for django-webtest auth system """

--- a/django_webtest/middleware.py
+++ b/django_webtest/middleware.py
@@ -8,7 +8,7 @@ if django.VERSION >= (1, 10):
 else:
     MiddlewareMixin = object
 
-from .compat import is_authenticated
+from django_webtest.compat import is_authenticated
 
 
 class WebtestUserMiddleware(RemoteUserMiddleware):


### PR DESCRIPTION
unsure why, but get

```
>   from .compat import is_authenticated
E   ImportWarning: can't resolve package from __spec__ or __package__, falling back on __name__ and __path__
```

making the imports absolute seems to fix it