### PR TITLE
restore MIDDLEWARE_CLASSES support #84

### DIFF
--- a/django_webtest/__init__.py
+++ b/django_webtest/__init__.py
@@ -285,7 +285,7 @@ class WebTestMixin(object):
         try:
             return self._middleware_setting_name
         except AttributeError:
-            if hasattr(settings, 'MIDDLEWARE'):
+            if getattr(settings, 'MIDDLEWARE', None) is not None:
                 name = 'MIDDLEWARE'
             else:
                 name = 'MIDDLEWARE_CLASSES'

--- a/django_webtest_tests/testapp_tests/tests.py
+++ b/django_webtest_tests/testapp_tests/tests.py
@@ -466,3 +466,15 @@ class MiddlewareTest(WebTest):
             self.middleware_setting_name,
             'MIDDLEWARE'
         )
+
+
+@skipIf(django.VERSION < (1, 10) or django.VERSION >= (2, 0),
+        'MIDDLEWARE is added in Django 1.10')
+@override_settings(MIDDLEWARE=None, MIDDLEWARE_CLASSES=[])
+class MiddlewareClassesTest(WebTest):
+
+    def test_middleware_setting_name(self):
+        self.assertEqual(
+            self.middleware_setting_name,
+            'MIDDLEWARE_CLASSES'
+        )


### PR DESCRIPTION
Can't find a proper way to test for django 2.0.
With the test I wrote, if fails in django 2.0 with : 

```python
File "/home/cazino/src/django-webtest/django_webtest/__init__.py", line 48, in get_wsgi_handler
    return StaticFilesHandler(WSGIHandler())
  File "/home/cazino/src/django-webtest/.tox/py36-django20-postgres/lib/python3.6/site-packages/django/core/handlers/wsgi.py", line 140, in __init__                                                              
    self.load_middleware()
  File "/home/cazino/src/django-webtest/.tox/py36-django20-postgres/lib/python3.6/site-packages/django/core/handlers/base.py", line 36, in load_middleware                                                        
    for middleware_path in reversed(settings.MIDDLEWARE):
TypeError: 'NoneType' object is not reversible
```
I am not familiar with django internals , no idea on how to workarond that in the test. So I skipped the test for django 2.0, assuming using MIDDLEWARE_CLASSES with django 2.0 is really a corner case.
