### PR TITLE
fix compatibility with django 3

### DIFF
--- a/django_webtest/__init__.py
+++ b/django_webtest/__init__.py
@@ -6,7 +6,8 @@ from django.test.signals import template_rendered
 from django.core.handlers.wsgi import WSGIHandler
 from django.test import TestCase, TransactionTestCase
 from django.test.client import store_rendered_templates
-from django.utils.functional import curry
+
+from functools import partial
 
 try:
     from importlib import import_module
@@ -91,7 +92,7 @@ class DjangoTestApp(TestApp):
             # Curry a data dictionary into an instance of the template renderer
             # callback function.
             data = {}
-            on_template_render = curry(store_rendered_templates, data)
+            on_template_render = partial(store_rendered_templates, data)
             template_rendered.connect(on_template_render)
 
             response = super(DjangoTestApp, self).do_request(req, status,


### PR DESCRIPTION
the curry function will be removed in django 3. Replaced with a partial, which does the same job and is also available for python2.