### PR TITLE
Update codebase for Django 3 and Python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,3 +64,33 @@ matrix:
       env: TOXENV=py36-django30-clocale
     - python: "3.6"
       env: TOXENV=py36-django30-postgres
+    - python: "3.7"
+      env: TOXENV=py37-django21-std
+    - python: "3.7"
+      env: TOXENV=py37-django21-clocale
+    - python: "3.7"
+      env: TOXENV=py37-django21-postgres
+    - python: "3.7"
+      env: TOXENV=py37-django22-std
+    - python: "3.7"
+      env: TOXENV=py37-django22-clocale
+    - python: "3.7"
+      env: TOXENV=py37-django22-postgres
+    - python: "3.7"
+      env: TOXENV=py37-django30-std
+    - python: "3.7"
+      env: TOXENV=py37-django30-clocale
+    - python: "3.7"
+      env: TOXENV=py37-django30-postgres
+    - python: "3.8"
+      env: TOXENV=py38-django22-std
+    - python: "3.8"
+      env: TOXENV=py38-django22-clocale
+    - python: "3.8"
+      env: TOXENV=py38-django22-postgres
+    - python: "3.8"
+      env: TOXENV=py38-django30-std
+    - python: "3.8"
+      env: TOXENV=py38-django30-clocale
+    - python: "3.8"
+      env: TOXENV=py38-django30-postgres

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,17 +23,23 @@ matrix:
     - python: "2.7"
       env: TOXENV=py27-django111-postgres
     - python: "3.5"
-      env: TOXENV=py35-django111-std
-    - python: "3.5"
-      env: TOXENV=py35-django111-clocale
-    - python: "3.5"
-      env: TOXENV=py35-django111-postgres
-    - python: "3.5"
       env: TOXENV=py35-django21-std
     - python: "3.5"
       env: TOXENV=py35-django21-clocale
     - python: "3.5"
       env: TOXENV=py35-django21-postgres
+    - python: "3.6"
+      env: TOXENV=py36-django21-std
+    - python: "3.6"
+      env: TOXENV=py36-django21-clocale
+    - python: "3.6"
+      env: TOXENV=py36-django21-postgres
+    - python: "3.7"
+      env: TOXENV=py37-django21-std
+    - python: "3.7"
+      env: TOXENV=py37-django21-clocale
+    - python: "3.7"
+      env: TOXENV=py37-django21-postgres
     - python: "3.5"
       env: TOXENV=py35-django22-std
     - python: "3.5"
@@ -41,23 +47,23 @@ matrix:
     - python: "3.5"
       env: TOXENV=py35-django22-postgres
     - python: "3.6"
-      env: TOXENV=py36-django111-std
-    - python: "3.6"
-      env: TOXENV=py36-django111-clocale
-    - python: "3.6"
-      env: TOXENV=py36-django111-postgres
-    - python: "3.6"
-      env: TOXENV=py36-django21-std
-    - python: "3.6"
-      env: TOXENV=py36-django21-clocale
-    - python: "3.6"
-      env: TOXENV=py36-django21-postgres
-    - python: "3.6"
       env: TOXENV=py36-django22-std
     - python: "3.6"
       env: TOXENV=py36-django22-clocale
     - python: "3.6"
       env: TOXENV=py36-django22-postgres
+    - python: "3.7"
+      env: TOXENV=py37-django22-std
+    - python: "3.7"
+      env: TOXENV=py37-django22-clocale
+    - python: "3.7"
+      env: TOXENV=py37-django22-postgres
+    - python: "3.8"
+      env: TOXENV=py38-django22-std
+    - python: "3.8"
+      env: TOXENV=py38-django22-clocale
+    - python: "3.8"
+      env: TOXENV=py38-django22-postgres
     - python: "3.6"
       env: TOXENV=py36-django30-std
     - python: "3.6"
@@ -65,29 +71,11 @@ matrix:
     - python: "3.6"
       env: TOXENV=py36-django30-postgres
     - python: "3.7"
-      env: TOXENV=py37-django21-std
-    - python: "3.7"
-      env: TOXENV=py37-django21-clocale
-    - python: "3.7"
-      env: TOXENV=py37-django21-postgres
-    - python: "3.7"
-      env: TOXENV=py37-django22-std
-    - python: "3.7"
-      env: TOXENV=py37-django22-clocale
-    - python: "3.7"
-      env: TOXENV=py37-django22-postgres
-    - python: "3.7"
       env: TOXENV=py37-django30-std
     - python: "3.7"
       env: TOXENV=py37-django30-clocale
     - python: "3.7"
       env: TOXENV=py37-django30-postgres
-    - python: "3.8"
-      env: TOXENV=py38-django22-std
-    - python: "3.8"
-      env: TOXENV=py38-django22-clocale
-    - python: "3.8"
-      env: TOXENV=py38-django22-postgres
     - python: "3.8"
       env: TOXENV=py38-django30-std
     - python: "3.8"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python.pythonPath": "/usr/local/bin/python3"
+}

--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -23,3 +23,4 @@ Authors
 * Max Kharandziuk <https://github.com/kharandziuk>
 * Helen Sherwood-Taylor <https://github.com/helenst>
 * Éric Araujo <https://github.com/merwok>
+* Wayne Lambert <https://github.com/WayneLambert>

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,12 @@ CHANGES
 1.9.8 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Update testing configurations for Django and Python as per Django documentation
+    - https://docs.djangoproject.com/en/3.0/faq/install/#what-python-version-can-i-use-with-django
+
+- Add some useful metadata for the project's PyPI listing
+
+- Minor changes to documentation
 
 
 1.9.7 (2019-07-05)

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2010-2015 Mikhail Korobov
+Copyright (c) 2010-2020 Mikhail Korobov
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ django-webtest
    :alt: Build Status
 
 django-webtest is an app for instant integration of Ian Bicking's
-WebTest (http://docs.pylonsproject.org/projects/webtest/) with django's
+WebTest (http://docs.pylonsproject.org/projects/webtest/) with Django's
 testing framework.
 
 Installation
@@ -68,17 +68,17 @@ For 500 errors original traceback is shown instead of usual html result
 from handler500.
 
 You also get the ``response.templates`` and ``response.context`` goodness that
-is usually only available if you use django's native test client. These
+is usually only available if you use Django's native test client. These
 attributes contain a list of templates that were used to render the response
-and the context used to render these templates. All of django's native asserts (
+and the context used to render these templates. All of Django's native asserts (
 ``assertFormError``,  ``assertTemplateUsed``, ``assertTemplateNotUsed``,
 ``assertContains``, ``assertNotContains``, ``assertRedirects``) are
 also supported for WebTest responses.
 
 The session dictionary is available via ``self.app.session``, and has the
-same content than django's native test client.
+same content than Django's native test client.
 
-Unlike django's native test client CSRF checks are not suppressed
+Unlike Django's native test client CSRF checks are not suppressed
 by default so missing CSRF tokens will cause test fails (and that's good).
 
 If forms are submitted via WebTest forms API then all form fields (including
@@ -87,7 +87,7 @@ CSRF token) are submitted automagically::
     class AuthTest(WebTest):
         fixtures = ['users.json']
 
-        def test_login(self)
+        def test_login(self):
             form = self.app.get(reverse('auth_login')).form
             form['username'] = 'foo'
             form['password'] = 'bar'
@@ -101,14 +101,14 @@ csrf tokens become hard to construct. CSRF checks can be disabled by setting
     class MyTestCase(WebTest):
         csrf_checks = False
 
-        def test_post(self)
+        def test_post(self):
             self.app.post('/')
 
-When a subclass of django's ``TransactionTestCase`` is desired,
+When a subclass of Django's ``TransactionTestCase`` is desired,
 use ``django_webtest.TransactionWebTest``.
 
 All of these features can be easily set up manually (thanks to WebTest
-architecture) and they are even not neccessary for using WebTest with django but
+architecture) and they are even not neccessary for using WebTest with Django but
 it is nice to have some sort of integration instantly.
 
 See http://docs.pylonsproject.org/projects/webtest/ for API help. Webtest can
@@ -125,7 +125,7 @@ authentication system with ``app.get(user=user)``.
 
 .. __: https://www.django-rest-framework.org/
 
-Usage with pytest
+Usage with PyTest
 =================
 
 You need to install `pytest-django <https://pytest-django.readthedocs.io>`_::
@@ -136,16 +136,18 @@ Then you can use ``django-webtest``'s fixtures::
 
     def test_1(django_app):
         resp = django_app.get('/')
+        assert resp.status_code == 200, 'Should return a 200 status code'
 
     def test_2(django_app_factory):
         app = django_app_factory(csrf_checks=False, extra_environ={})
         resp = app.get('/')
+        assert resp.status_code == 200, 'Should return a 200 status code'
 
 Why?
 ====
 
 While django.test.client.Client is fine for its purposes, it is not
-well-suited for functional or integration testing. From django's test client
+well-suited for functional or integration testing. From Django's test client
 docstring:
 
     This is not intended as a replacement for Twill/Selenium or
@@ -157,7 +159,7 @@ WebTest plays on the same field as twill. WebTest has a nice API,
 is fast, small, talks to the django application via WSGI instead of HTTP
 and is an easy way to write functional/integration/acceptance tests.
 django-webtest is able to provide access to the names of rendered templates
-and template context just like native django TestClient.
+and template context just like native Django TestClient.
 
 Contributing
 ============
@@ -179,4 +181,3 @@ Make sure `tox`_ is installed and run
 from the source checkout.
 
 .. _tox: http://tox.testrun.org
-

--- a/django_webtest/middleware.py
+++ b/django_webtest/middleware.py
@@ -29,10 +29,9 @@ class WebtestUserMiddleware(RemoteUserMiddleware):
             raise ImproperlyConfigured(
                 "The django-webtest auth middleware requires the "
                 "'django.contrib.auth.middleware.AuthenticationMiddleware' "
-                "to be installed. Add it to your MIDDLEWARE_CLASSES setting "
-                "or disable django-webtest auth support "
-                "by setting 'setup_auth' property of your WebTest subclass "
-                "to False."
+                "to be installed. Add it to your MIDDLEWARE setting "
+                "or disable django-webtest auth support by setting "
+                "'setup_auth' property of your WebTest subclass to False."
             )
         try:
             username = request.META[self.header]

--- a/django_webtest_tests/tox2travis.py
+++ b/django_webtest_tests/tox2travis.py
@@ -36,7 +36,7 @@ if __name__ == '__main__':
                     py = 'pypy'
                 else:
                     py = '{0}.{1}'.format(env[2], env[3])
-                    if int(env[2] + env[3]) > 36:
+                    if int(env[2] + env[3]) > 38:
                         # looks like psql dos not work on xenial... skip 3.7
                         # for now
                         continue

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     description=(
         "Instant integration of Ian Bicking's WebTest "
         "(http://docs.pylonsproject.org/projects/webtest/) "
-        "with django's testing framework."
+        "with Django's testing framework."
     ),
 
     long_description=get_long_description(),
@@ -48,6 +48,11 @@ setup(
         'Development Status :: 5 - Production/Stable',
         'Environment :: Web Environment',
         'Framework :: Django',
+        'Framework :: Django :: 1.11',
+        'Framework :: Django :: 2.0',
+        'Framework :: Django :: 2.1',
+        'Framework :: Django :: 2.2',
+        'Framework :: Django :: 3.0',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python',
@@ -62,4 +67,10 @@ setup(
         'Topic :: Software Development :: Libraries :: Python Modules',
         'Topic :: Software Development :: Testing',
     ],
+    project_urls={
+        'Code': 'https://github.com/django-webtest/django-webtest',
+        'Issue Tracker': 'https://github.com/django-webtest/django-webtest/issues',
+        'Changelog': 'https://github.com/django-webtest/django-webtest/blob/master/CHANGES.rst',
+    },
+    keywords=['django', 'webtest', 'pytest'],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,9 @@
 skip_missing_interpreters = true
 envlist =
     py27-django{111}-{std,clocale,postgres},
-    {py35,py36,py37}-django{111,21,22}-{std,clocale,postgres}
-    {py36,py37}-django{30}-{std,clocale,postgres}
+    {py35,py36,py37}-django{21}-{std,clocale,postgres}
+    {py35,py36,py37,py38}-django{22}-{std,clocale,postgres}
+    {py36,py37,py38}-django{30}-{std,clocale,postgres}
 
 [testenv]
 deps=


### PR DESCRIPTION
Added configurations to `travis.yml`, `setup.py` and `tox.ini` to account for the various compatibility versions between Django and Python (as listed [here on the Django website](https://docs.djangoproject.com/en/3.0/faq/install/#what-python-version-can-i-use-with-django))

- Added metadata to `setup.py` to inform developers of compatiblity. You may wish to delete `'Programming Language :: Python :: 2',`
- Added some project url's to aid navigation for developers exploring the project from PyPI
- Added keywords to `setup.py` to aid discoverability
- Updated `CHANGES.rst` to add compatibility for Django 3 and Python 3.8.
- Also corrected a couple of typos in `README.rst`.
- Updated `AUTHORS.txt` to include myself.
- Updated the year on `LICENSE.txt`.
- Changed the `MIDDLEWARE_CLASSES` settings message to just the newer `MIDDLEWARE` setting which will be far more common nowadays.

Please feel free to make any changes as you see fit and squash the commits if you think is neater.

I ran `$ tox` locally and many of the tests passed, however I don't have all of the Python interpreters on my machine and nor do I have a local installation of Postgres as I favour Postgres development with Docker.

I have left the version numbering and dates as is. You can change these on `setup.py` and `CHANGES.rst` when you feel that it passes the tests and can come out of dev and finally be published to PyPI.

Any questions, please feel free to reach out.