### PR TITLE
Pass the request instance to authenticate function

### DIFF
--- a/django_webtest/middleware.py
+++ b/django_webtest/middleware.py
@@ -53,7 +53,7 @@ class WebtestUserMiddleware(RemoteUserMiddleware):
                 return
         # We are seeing this user for the first time in this session, attempt
         # to authenticate the user.
-        user = auth.authenticate(django_webtest_user=username)
+        user = auth.authenticate(request=request, django_webtest_user=username)
         if user:
             # User is valid.  Set request.user and persist user in the session
             # by logging the user in.


### PR DESCRIPTION
Django's authentication function accepts a request 

https://github.com/django/django/blob/master/django/contrib/auth/__init__.py#L61

however we were not passing the request to it.  

I think it's useful to pass this along since some backends expect a request to be present.