### PR TITLE
Use assertEqual instead of assertEquals for Python 3.11 compatibility.

### DIFF
--- a/django_webtest_tests/testapp_tests/tests.py
+++ b/django_webtest_tests/testapp_tests/tests.py
@@ -248,7 +248,7 @@ class AuthTest(BaseAuthTest):
         self.assertIn('sessionid', self.app.cookies)
 
         resp = self.app.get(reverse('protected'))
-        self.assertEquals(resp.status_int, 200)
+        self.assertEqual(resp.status_int, 200)
         resp.mustcontain('ok: {0}'.format(self.user.username))
 
     def test_reusing_custom_user(self):


### PR DESCRIPTION
The deprecated aliases have been removed in python/cpython#28268