### PR TITLE
Use tox's allowlist_externals, upgrade Postgres version in tox.yml 

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -15,7 +15,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:10.8
+        image: postgres:15.1
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres

--- a/tox.ini
+++ b/tox.ini
@@ -23,7 +23,7 @@ passenv =
     POSTGRES_USER
     POSTGRES_PASSWORD
     POSTGRES_NAME
-whitelist_externals = env
+allowlist_externals = env
 changedir=django_webtest_tests
 commands=
     env


### PR DESCRIPTION
`allowlist_externals` has replaced `whitelist_externals`: https://tox.wiki/en/latest/changelog.html#deprecations-and-removals-4-0-0rc4

Without this change, i got errors like this when running `tox`:

```
(env) kees@kees-XPS-13-9300 ~/Projects/django-webtest (master) $ tox
py37-django30-std: install_deps> python -I -m pip install 'django<=3.1,>=3.0' pytest pytest-django
.pkg: install_requires> python -I -m pip install 'setuptools>=40.8.0' wheel
.pkg: _optional_hooks> python /home/kees/Projects/django-webtest/env/lib/python3.10/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
.pkg: get_requires_for_build_sdist> python /home/kees/Projects/django-webtest/env/lib/python3.10/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
.pkg: prepare_metadata_for_build_wheel> python /home/kees/Projects/django-webtest/env/lib/python3.10/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
.pkg: build_sdist> python /home/kees/Projects/django-webtest/env/lib/python3.10/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
py37-django30-std: install_package_deps> python -I -m pip install 'webtest>=1.3.3'
py37-django30-std: install_package> python -I -m pip install --force-reinstall --no-deps /home/kees/Projects/django-webtest/.tox/.tmp/package/1/django-webtest-1.9.11.dev0.tar.gz
py37-django30-std: commands[0] /home/kees/Projects/django-webtest/django_webtest_tests> env
py37-django30-std: failed with env is not allowed, use allowlist_externals to allow it
```