### PR TITLE
Do not insert  WebtestAuthentication to the head of DEFAULT_AUTHENTICATION_CLASSES.

### DIFF
--- a/django_webtest/__init__.py
+++ b/django_webtest/__init__.py
@@ -301,7 +301,7 @@ class WebTestMixin(object):
         if class_name not in classes:
             if isinstance(classes, tuple):
                 classes = list(classes)
-            classes.insert(0, class_name)
+            classes.append(class_name)
             drf_settings['DEFAULT_AUTHENTICATION_CLASSES'] = classes
 
     @property


### PR DESCRIPTION
Hello. authors. Thanks for awsome tool. 

I have found a problem using restframwork and django-webtest together.

The following code expects to return an `HTTP 401` on an authentication error.

```python
REST_FRAMEWORK = {
    'DEFAULT_AUTHENTICATION_CLASSES': [
        'rest_framework.authentication.TokenAuthentication',.
    ]
}
```

But django-webtest returns `HTTP 403`.

The reason for this is described in the restframework documentation.

> HTTP 401 responses must always include a WWW-Authenticate header, that instructs the client how to authenticate. HTTP 403 responses do not include the WWW-Authenticate header.
> 
> The kind of response that will be used depends on the authentication scheme. Although multiple authentication schemes may be in use, only one scheme may be The first authentication class set on the view is used when determining > the type of response.
> https://www.django-rest-framework.org/api-guide/authentication/#unauthorized-and-forbidden-response

In other words, restframework determines whether to return HTTP 401 or HTTP 403 depending on the head of the DEFAULT_AUTHENTICATION_CLASSES.

Since djang-webtest adds WebtestAuthentication to the head of DEFAULT_AUTHENTICATION_CLASSES, it may return an HTTP status code that is not what the user expects.

To avoid breaking the user's expected results, i fix codes.
Please feel free to merge it. 

Thanks.

