### PR TITLE
Session key missing in subsequent request

### DIFF
--- a/django_webtest_tests/settings.py
+++ b/django_webtest_tests/settings.py
@@ -86,6 +86,7 @@ MIDDLEWARE = (
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'testapp_tests.middleware.UserMiddleware',
+    'allauth.usersessions.middleware.UserSessionsMiddleware',
 )
 
 if django.VERSION < (1, 10):
@@ -102,6 +103,9 @@ INSTALLED_APPS = (
     'django_webtest',
     'django_webtest_tests',
     'django_webtest_tests.testapp_tests',
+    'allauth',
+    'allauth.usersessions',
 )
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
+USERSESSIONS_TRACK_ACTIVITY = True

--- a/django_webtest_tests/testapp_tests/tests.py
+++ b/django_webtest_tests/testapp_tests/tests.py
@@ -471,7 +471,10 @@ class TestSession(WebTest):
         test_user = User.objects.create(username='test_user')
         second_user = User.objects.create(username='second_user')
         self.app.get('/', user=test_user)
-        self.app.get('/', user=second_user)
+        try:
+            self.app.get('/', user=second_user)
+        except ValueError:
+            self.fail('Exception unexpectedly raised')
 
 
 class TestHeaderAccess(WebTest):

--- a/django_webtest_tests/testapp_tests/tests.py
+++ b/django_webtest_tests/testapp_tests/tests.py
@@ -467,6 +467,12 @@ class TestSession(WebTest):
         self.app.get(reverse('set_session'))
         self.assertEqual('foo', self.app.session['test'])
 
+    def test_second_request_has_session_key(self):
+        test_user = User.objects.create(username='test_user')
+        second_user = User.objects.create(username='second_user')
+        self.app.get('/', user=test_user)
+        self.app.get('/', user=second_user)
+
 
 class TestHeaderAccess(WebTest):
     def test_headers(self):


### PR DESCRIPTION
This branch demonstrates the bug mentioned in https://github.com/django-webtest/django-webtest/issues/130. Unfortunately, I wasn't able to overwrite the settings for this test specifically, so I had to modify the settings.py file. The packages and versions I used were: `Django==4.2` and `django-allauth==0.60.1`. Hope this helps and let me know if I can provide more information for you. 