### PR TITLE
django_app_factory doesn't unpatch Django settings

### DIFF
--- a/django_webtest/pytest_plugin.py
+++ b/django_webtest/pytest_plugin.py
@@ -31,8 +31,9 @@ def django_app(django_app_mixin):
 
 @pytest.fixture
 def django_app_factory():
+    app_mixin = MixinWithInstanceVariables()
+
     def factory(csrf_checks=True, extra_environ=None):
-        app_mixin = MixinWithInstanceVariables()
         app_mixin.csrf_checks = csrf_checks
         if extra_environ:
             app_mixin.extra_environ = extra_environ
@@ -41,3 +42,5 @@ def django_app_factory():
         return app_mixin.app
 
     yield factory
+    
+    app_mixin._unpatch_settings()

--- a/django_webtest_tests/test_pytest.py
+++ b/django_webtest_tests/test_pytest.py
@@ -1,5 +1,12 @@
 # -*- coding: utf-8 -*-
 
+import pytest
+from django.conf import settings
+
+initial_settings = {
+    "DEBUG_PROPAGATE_EXCEPTIONS": settings.DEBUG_PROPAGATE_EXCEPTIONS,
+    "AUTHENTICATION_BACKENDS": settings.AUTHENTICATION_BACKENDS,
+}
 
 def test_django_app(django_app):
     resp = django_app.get('/')
@@ -10,3 +17,9 @@ def test_django_app_post(django_app_factory):
     app = django_app_factory(csrf_checks=False)
     resp = app.post('/')
     assert resp.status_int == 200
+
+@pytest.mark.xfail(reason="django_app_factory does not unpatch settings")
+def test_app_factory():
+    """Ensure django_app_factory properly resets settings."""
+    assert settings.DEBUG_PROPAGATE_EXCEPTIONS is initial_settings["DEBUG_PROPAGATE_EXCEPTIONS"]
+    assert settings.AUTHENTICATION_BACKENDS == initial_settings["AUTHENTICATION_BACKENDS"]

--- a/django_webtest_tests/test_pytest.py
+++ b/django_webtest_tests/test_pytest.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-import pytest
 from django.conf import settings
 
 initial_settings = {
@@ -18,7 +17,6 @@ def test_django_app_post(django_app_factory):
     resp = app.post('/')
     assert resp.status_int == 200
 
-@pytest.mark.xfail(reason="django_app_factory does not unpatch settings")
 def test_app_factory():
     """Ensure django_app_factory properly resets settings."""
     assert settings.DEBUG_PROPAGATE_EXCEPTIONS is initial_settings["DEBUG_PROPAGATE_EXCEPTIONS"]


### PR DESCRIPTION
When the fixture `django_app_factory` is used, the modifications it applies during setup aren't reset when the fixture is not in use anymore. This pollutes other tests relying on pristine Django settings. 