### PR TITLE
Add support for Django 5.2

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -10,13 +10,15 @@ jobs:
     strategy:
       matrix:
         python: ["3.9", "3.10", "3.11", "3.12"]
-        django: ["42", "50", "51"]
+        django: ["42", "50", "51", "52"]
         suffix: [std, clocale, postgres]
         exclude:
           - python: "3.9"
             django: "50"
           - python: "3.9"
             django: "51"
+          - python: "3.9"
+            django: "52"
 
     services:
       postgres:

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         python: ["3.9", "3.10", "3.11", "3.12"]
-        django: ["32", "41", "42", "50"]
+        django: ["42", "50"]
         suffix: [std, clocale, postgres]
         exclude:
           - python: "3.9"

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -10,11 +10,13 @@ jobs:
     strategy:
       matrix:
         python: ["3.9", "3.10", "3.11", "3.12"]
-        django: ["42", "50"]
+        django: ["42", "50", "51"]
         suffix: [std, clocale, postgres]
         exclude:
           - python: "3.9"
             django: "50"
+          - python: "3.9"
+            django: "51"
 
     services:
       postgres:

--- a/django_webtest/middleware.py
+++ b/django_webtest/middleware.py
@@ -23,7 +23,7 @@ class WebtestUserMiddleware(RemoteUserMiddleware):
 
     header = "WEBTEST_USER"
 
-    def process_request(self, request):
+    def __call__(self, request):
         # AuthenticationMiddleware is required so that request.user exists.
         if not hasattr(request, 'user'):
             raise ImproperlyConfigured(
@@ -39,7 +39,7 @@ class WebtestUserMiddleware(RemoteUserMiddleware):
             # If specified header doesn't exist then return (leaving
             # request.user set to AnonymousUser by the
             # AuthenticationMiddleware).
-            return
+            return self.get_response(request)
         # If the user is already authenticated and that user is the user we are
         # getting passed in the headers, then the correct user is already
         # persisted in the session and we don't need to continue.
@@ -50,7 +50,7 @@ class WebtestUserMiddleware(RemoteUserMiddleware):
                 authenticated_username = request.user.username
             clean_username = self.clean_username(username, request)
             if authenticated_username == clean_username:
-                return
+                return self.get_response(request)
         # We are seeing this user for the first time in this session, attempt
         # to authenticate the user.
         user = auth.authenticate(request=request, django_webtest_user=username)
@@ -59,6 +59,7 @@ class WebtestUserMiddleware(RemoteUserMiddleware):
             # by logging the user in.
             request.user = user
             auth.login(request, user)
+        return self.get_response(request)
 
 
 class DisableCSRFCheckMiddleware(MiddlewareMixin):

--- a/setup.py
+++ b/setup.py
@@ -48,8 +48,6 @@ setup(
         'Development Status :: 5 - Production/Stable',
         'Environment :: Web Environment',
         'Framework :: Django',
-        'Framework :: Django :: 3.2',
-        'Framework :: Django :: 4.1',
         'Framework :: Django :: 4.2',
         'Framework :: Django :: 5.0',
         'Intended Audience :: Developers',

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ setup(
         'Framework :: Django :: 4.2',
         'Framework :: Django :: 5.0',
         'Framework :: Django :: 5.1',
+        'Framework :: Django :: 5.2',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python',

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ setup(
         'Framework :: Django',
         'Framework :: Django :: 4.2',
         'Framework :: Django :: 5.0',
+        'Framework :: Django :: 5.1',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python',

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 skip_missing_interpreters = true
 envlist =
-    {py39,py311,py312}-django{42,50,51}-{std,clocale,postgres}
+    {py39,py311,py312}-django{42,50,51,52}-{std,clocale,postgres}
 
 [testenv]
 deps=
@@ -11,6 +11,7 @@ deps=
     django42: django >=4.2, <5.0
     django50: django >=5.0, <5.1
     django51: django >=5.1, <5.2
+    django52: django >=5.2, <6.0
 setenv=
     clocale: LC_ALL=C
     postgres: USE_POSTGRES=true

--- a/tox.ini
+++ b/tox.ini
@@ -8,8 +8,8 @@ deps=
     pytest
     pytest-django
     postgres: psycopg2-binary
-    django42: django >=4.2, <=4.3
-    django50: django >=5.0, <=5.1
+    django42: django >=4.2, <4.3
+    django50: django >=5.0, <5.1
 setenv=
     clocale: LC_ALL=C
     postgres: USE_POSTGRES=true

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 skip_missing_interpreters = true
 envlist =
-    {py39,py311,py312}-django{42,50}-{std,clocale,postgres}
+    {py39,py311,py312}-django{42,50,51}-{std,clocale,postgres}
 
 [testenv]
 deps=
@@ -10,6 +10,7 @@ deps=
     postgres: psycopg2-binary
     django42: django >=4.2, <5.0
     django50: django >=5.0, <5.1
+    django51: django >=5.1, <5.2
 setenv=
     clocale: LC_ALL=C
     postgres: USE_POSTGRES=true

--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,13 @@
 [tox]
 skip_missing_interpreters = true
 envlist =
-    {py39,py311,py312}-django{32,41,42,50}-{std,clocale,postgres}
+    {py39,py311,py312}-django{42,50}-{std,clocale,postgres}
 
 [testenv]
 deps=
     pytest
     pytest-django
     postgres: psycopg2-binary
-    django32: django >=3.2, <=3.3
-    django41: django >=4.1, <=4.2
     django42: django >=4.2, <=4.3
     django50: django >=5.0, <=5.1
 setenv=

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ deps=
     pytest
     pytest-django
     postgres: psycopg2-binary
-    django42: django >=4.2, <4.3
+    django42: django >=4.2, <5.0
     django50: django >=5.0, <5.1
 setenv=
     clocale: LC_ALL=C


### PR DESCRIPTION
This PR adds support for Django 5.2 by making a necessary fix to the `WebtestUserMiddleware` that no longer inherits `MiddlewareMixin` (errors can be seen [here](https://github.com/jamesbeith/django-webtest/actions/runs/14099763595/job/39493673857#step:6:177)).